### PR TITLE
allow IdentifierExpression as argument in Function

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -186,11 +186,11 @@ class FunctionsBuilder
      * Returns the specified date part from the SQL expression.
      *
      * @param string $part Part of the date to return.
-     * @param string $expression Expression to obtain the date part from.
+     * @param mixed $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function datePart(string $part, string $expression, array $types = []): FunctionExpression
+    public function datePart(string $part, $expression, array $types = []): FunctionExpression
     {
         return $this->extract($part, $expression, $types);
     }
@@ -199,11 +199,11 @@ class FunctionsBuilder
      * Returns the specified date part from the SQL expression.
      *
      * @param string $part Part of the date to return.
-     * @param string $expression Expression to obtain the date part from.
+     * @param mixed $expression Expression to obtain the date part from.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function extract(string $part, string $expression, array $types = []): FunctionExpression
+    public function extract(string $part, $expression, array $types = []): FunctionExpression
     {
         $expression = $this->_literalArgumentFunction('EXTRACT', $expression, $types, 'integer');
         $expression->setConjunction(' FROM')->add([$part => 'literal'], [], true);
@@ -214,13 +214,13 @@ class FunctionsBuilder
     /**
      * Add the time unit to the date expression
      *
-     * @param string $expression Expression to obtain the date part from.
+     * @param mixed $expression Expression to obtain the date part from.
      * @param string|int $value Value to be added. Use negative to subtract.
      * @param string $unit Unit of the value e.g. hour or day.
      * @param array $types list of types to bind to the arguments
      * @return \Cake\Database\Expression\FunctionExpression
      */
-    public function dateAdd(string $expression, $value, string $unit, array $types = []): FunctionExpression
+    public function dateAdd($expression, $value, string $unit, array $types = []): FunctionExpression
     {
         if (!is_numeric($value)) {
             $value = 0;


### PR DESCRIPTION
The following code was valid in CakePHP 3.x

```php
$query->func()->dateAdd(new IdentifierExpression($this->aliasField('valid_until')), 1, 'day'), (new FrozenTime('now')), 'datetime'),
```

but is invalid as $expression has enforcement of type string now. However this affects date functions only. It's still fine for other functions so this proposed to revert this change